### PR TITLE
Changed error ReadyState

### DIFF
--- a/src/xhr-xdr-adapter.js
+++ b/src/xhr-xdr-adapter.js
@@ -117,7 +117,7 @@
             request.onerror = function () {
                 self.status = 400;
                 self.statusText = "Error";
-                self._setReadyState(0);
+                self._setReadyState(4);
                 if (self.onerror) {
                     self.onerror();
                 }


### PR DESCRIPTION
I'm not certain I have htis right for every use case, but it certainly helped in mine.

I have changed the Ready state of the on error event to complete so that the error is processed. In IE9 my AngularJS application wouldn’t pick up the fact the request resulted in an error.
