### PR TITLE
Handle "same-scheme" URLs

### DIFF
--- a/src/xhr-xdr-adapter.js
+++ b/src/xhr-xdr-adapter.js
@@ -69,6 +69,12 @@
         var crossDomain;
 
         try {
+            // check to see if this is a "same-scheme" URL ("//example.com").
+            // prepend location.protocol if so.
+            if (remoteUrl[0] === '/' && remoteUrl[1] === '/') {
+                remoteUrl = location.protocol + remoteUrl;
+            }
+         
             // account for the possibility of a <base href="..."> setting, which could make a URL that looks relative actually be cross-domain
             if ((remoteUrl && remoteUrl.indexOf("://") < 0) && document.getElementsByTagName('base').length > 0) {
                 baseHref = document.getElementsByTagName('base')[0].href;


### PR DESCRIPTION
xhr-xdr-adapter throws an exception if it receives a "same-scheme" URL, i.e., one that is relative with respect to protocol (of the form `//example.com`). This pull request resolves the exception by prepending location.protocol to remoteUrl. (NB: location.protocol already has the trailing colon, so no need to add that).
